### PR TITLE
QOL: Skip over hidden objects, and provide a more clear error when a packing error occurs (fixed)

### DIFF
--- a/io_scene_md3/__init__.py
+++ b/io_scene_md3/__init__.py
@@ -27,6 +27,7 @@ bl_info = {
 
 
 import bpy
+import struct
 from bpy.props import StringProperty
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 
@@ -52,10 +53,12 @@ class ExportMD3(bpy.types.Operator, ExportHelper):
     filter_glob = StringProperty(default="*.md3", options={'HIDDEN'})
 
     def execute(self, context):
-        from .export_md3 import MD3Exporter
-        MD3Exporter(context)(self.properties.filepath)
-        return {'FINISHED'}
-
+        try:
+            from .export_md3 import MD3Exporter
+            MD3Exporter(context)(self.properties.filepath)
+            return {'FINISHED'}
+        except struct.error:
+            self.report({'ERROR'}, "Mesh does not fit within the MD3 model space. Vertex axies locations must be below 512 blender units.")
 
 def menu_func_import(self, context):
     self.layout.operator(ImportMD3.bl_idname, text="Quake 3 Model (.md3)")

--- a/io_scene_md3/__init__.py
+++ b/io_scene_md3/__init__.py
@@ -59,6 +59,9 @@ class ExportMD3(bpy.types.Operator, ExportHelper):
             return {'FINISHED'}
         except struct.error:
             self.report({'ERROR'}, "Mesh does not fit within the MD3 model space. Vertex axies locations must be below 512 blender units.")
+        except ValueError as e:
+            self.report({'ERROR'}, str(e))
+        return {'CANCELLED'}
 
 def menu_func_import(self, context):
     self.layout.operator(ImportMD3.bl_idname, text="Quake 3 Model (.md3)")

--- a/io_scene_md3/export_md3.py
+++ b/io_scene_md3/export_md3.py
@@ -200,6 +200,9 @@ class MD3Exporter:
 
     def pack_surface(self, surf_name):
         obj = bpy.context.scene.objects[surf_name]
+        if obj.hide:
+            return b''
+
         bpy.context.scene.objects.active = obj
         bpy.ops.object.modifier_add(type='TRIANGULATE')  # no 4-gons or n-gons
         self.mesh = obj.to_mesh(bpy.context.scene, True, 'PREVIEW')

--- a/io_scene_md3/export_md3.py
+++ b/io_scene_md3/export_md3.py
@@ -200,9 +200,6 @@ class MD3Exporter:
 
     def pack_surface(self, surf_name):
         obj = bpy.context.scene.objects[surf_name]
-        if obj.hide:
-            return b''
-
         bpy.context.scene.objects.active = obj
         bpy.ops.object.modifier_add(type='TRIANGULATE')  # no 4-gons or n-gons
         self.mesh = obj.to_mesh(bpy.context.scene, True, 'PREVIEW')
@@ -303,8 +300,11 @@ class MD3Exporter:
         self.mesh_vco = defaultdict(list)
 
         tags_bin = self.pack_animated_tags()
-        surfaces_bin = [self.pack_surface(name) for name in self.surfNames]
+        surfaces_bin = [self.pack_surface(name) for name in self.surfNames if not bpy.context.scene.objects[name].hide]
         frames_bin = [self.pack_frame(i) for i in range(self.nFrames)]
+
+        if len(surfaces_bin) == 0:
+            raise ValueError("At least one surface mesh must be visible in order to export.")
 
         f = OffsetBytesIO(start_offset=fmt.Header.size)
         f.mark('offFrames')
@@ -323,9 +323,9 @@ class MD3Exporter:
                 flags=0,  # ignored
                 nFrames=self.nFrames,
                 nTags=len(self.tagNames),
-                nSurfaces=len(self.surfNames),
+                nSurfaces=len(surfaces_bin),
                 nSkins=0,  # count of skins, ignored
                 **f.getoffsets()
             ))
             file.write(f.getvalue())
-            print('nFrames={} nSurfaces={}'.format(self.nFrames, len(self.surfNames)))
+            print('nFrames={} nSurfaces={}'.format(self.nFrames, len(surfaces_bin)))


### PR DESCRIPTION
The current triangulation method will fail on any object that is hidden. This may or may not be resolved with PR #1, where the triangulation does not require a context. However, it seems better, to me, to allow the user to selectively decide which pieces will be exported via hide/show instead.

Added a try/except to catch struct errors. Any error here will more than likely be the 32k short limit, so this message is more user friendly than the giant call stack. In my opinion.

This is a fixed version of PR #10 