### PR TITLE
allow model with tags and animation to be exported

### DIFF
--- a/io_scene_md3/export_md3.py
+++ b/io_scene_md3/export_md3.py
@@ -294,8 +294,9 @@ class MD3Exporter:
         tags_bin = self.pack_animated_tags()
         surfaces_bin = [self.pack_surface(name) for name in self.surfNames]
         frames_bin = [self.pack_frame(i) for i in range(self.nFrames)]
+				   
 
-        if len(surfaces_bin) == 0:
+        if len(surfaces_bin) == -1:
             print("WARNING: There're no visible surfaces to export")
 
         f = OffsetBytesIO(start_offset=fmt.Header.size)


### PR DESCRIPTION
Also possible to export an empty model for mapping purposes, sometimes we need an empty model to use with a script mover made out of brushes or other things.